### PR TITLE
Feat-9-Interactive-plots-with-tool-tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We adopt a Backend For Frontend Approach to load the data from the open targets 
 
 ### Prerequisites
 
-- Node.js ≥ 20
+- Node.js ≥ 22
 - npm ≥ 10
 
 ### Install

--- a/app/components/RadarChart.tsx
+++ b/app/components/RadarChart.tsx
@@ -4,12 +4,29 @@ import { useEffect, useRef } from "react";
 
 import { formatLabel } from "~/lib/labels";
 
+import type { Datum } from "./types";
+
 export type RadarItem = { id: string; score: number };
 type Props = { items: RadarItem[]; title: string };
 
 const styles = {
-  wrapper: { display: "flex", justifyContent: "center" },
+  wrapper: { display: "flex", justifyContent: "center", position: "relative" as const },
   svg: { width: "60%", height: "auto", display: "block" },
+  tooltip: {
+    position: "absolute" as const,
+    pointerEvents: "none" as const,
+    opacity: 0,
+    padding: "6px 8px",
+    borderRadius: 6,
+    fontSize: 12,
+    lineHeight: 1.2,
+    background: "rgba(17, 24, 39, 0.92)",
+    color: "#fff",
+    boxShadow: "0 2px 8px rgba(0,0,0,0.25)",
+    transform: "translate(8px, -50%)", // show to the side of the cursor
+    transition: "opacity 120ms ease",
+    zIndex: 1,
+  },
 } as const;
 
 
@@ -51,19 +68,34 @@ const styles = {
  * @returns {JSX.Element} A responsive radar chart rendered in an SVG element.
  */
 export default function RadarChart({ items, title }: Props) {
-  const ref = useRef<SVGSVGElement | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!ref.current) return;
+    if (!svgRef.current || !containerRef.current) return;
 
-    const svg = d3.select(ref.current);
+    const svg = d3.select(svgRef.current);
     svg.selectAll("*").remove();
 
-    // Canvas and geometry
+    // Ensure a single tooltip div
+    let tooltip = d3
+      .select(containerRef.current)
+      .select<HTMLDivElement>(".d3-tooltip");
+    if (tooltip.empty()) {
+      tooltip = d3.select(containerRef.current).append("div").attr("class", "d3-tooltip");
+      Object.entries(styles.tooltip).forEach(([k, v]) => {
+        (tooltip.node() as HTMLDivElement).style.setProperty(
+          k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`),
+          String(v)
+        );
+      });
+    }
+
+    // --- geometry
     const width = 640;
     const height = 500;
     const margin = 80;
-    const radius = Math.min(width, height) / 2 - margin; // to make sure the circle fits inside the width and height of the svg
+    const radius = Math.min(width, height) / 2 - margin;
 
     const g = svg
       .attr("viewBox", `0 0 ${width} ${height}`)
@@ -71,17 +103,10 @@ export default function RadarChart({ items, title }: Props) {
       .append("g")
       .attr("transform", `translate(${width / 2}, ${height / 2})`);
 
-    const data = items.map((d) => ({
-      label: formatLabel(d.id),
-      value: d.score,
-    }));
-
-    const numberOfAxis = data.length;
-    const angle = d3
-      .scaleLinear()
-      .domain([0, numberOfAxis])
-      .range([0, 2 * Math.PI]);
-    const radiusScale = d3.scaleLinear().domain([0, 1]).range([0, radius]);
+    const data: Datum[] = items.map((d) => ({ label: formatLabel(d.id), value: d.score ?? 0 }));
+    const n = data.length;
+    const angle = d3.scaleLinear().domain([0, n]).range([0, 2 * Math.PI]);
+    const r = d3.scaleLinear().domain([0, 1]).range([0, radius]);
 
     // To draw the rings in the radar chart
     const levels = [0, 0.25, 0.5, 0.75, 1];
@@ -90,7 +115,7 @@ export default function RadarChart({ items, title }: Props) {
       .enter()
       .append("circle")
       .attr("class", "grid")
-      .attr("r", (d) => radiusScale(d))
+      .attr("r", (d) => r(d))
       .attr("fill", "none")
       .attr("stroke", "#e5e7eb");
 
@@ -114,7 +139,7 @@ export default function RadarChart({ items, title }: Props) {
       .append("text")
       .attr("class", "tick")
       .attr("x", 0)
-      .attr("y", (d) => -radiusScale(d))
+      .attr("y", (d) => -r(d))
       .attr("dy", -4)
       .attr("text-anchor", "middle")
       .attr("font-size", 12)
@@ -122,7 +147,8 @@ export default function RadarChart({ items, title }: Props) {
       .text((d) => fmt(d));
 
     // Axis labels (category names)
-    g.selectAll("text.axis-label")
+      g
+      .selectAll<SVGTextElement, Datum>("text.axis-label")
       .data(data)
       .enter()
       .append("text")
@@ -135,39 +161,117 @@ export default function RadarChart({ items, title }: Props) {
       })
       .attr("dominant-baseline", "middle")
       .attr("font-size", 12)
-      .text((d) => d.label);
+      .text((d) => d.label)
+      .attr("tabindex", 0);
 
     const radialLine: d3.LineRadial<number> = d3
       .lineRadial<number>()
-      .radius((_v, i) => radiusScale(data[i].value))
+      .radius((_v, i) => r(data[i].value))
       .angle((_v, i) => angle(i))
       .curve(d3.curveLinearClosed);
 
-    g.append("path")
-      .datum<number[]>(data.map(d => d.value))
+    const polygon = g
+      .append("path")
+      .datum<number[]>(data.map((d) => d.value))
       .attr("d", (values: number[]) => radialLine(values) ?? "")
       .attr("fill", "rgba(31, 119, 180, 0.12)")
       .attr("stroke", "#1f77b4")
       .attr("stroke-width", 1);
 
-    // Markers
-    g.selectAll("circle.point")
+    // points
+    const points = g
+      .selectAll<SVGCircleElement, Datum>("circle.point")
       .data(data)
       .enter()
       .append("circle")
       .attr("class", "point")
-      .attr(
-        "cx",
-        (_d, i) => Math.cos(angle(i) - Math.PI / 2) * radiusScale(data[i].value)
-      )
-      .attr(
-        "cy",
-        (_d, i) => Math.sin(angle(i) - Math.PI / 2) * radiusScale(data[i].value)
-      )
+      .attr("cx", (_d, i) => Math.cos(angle(i) - Math.PI / 2) * r(data[i].value))
+      .attr("cy", (_d, i) => Math.sin(angle(i) - Math.PI / 2) * r(data[i].value))
       .attr("r", 3.5)
       .attr("fill", "#ffffff")
       .attr("stroke", "#1f77b4")
-      .attr("stroke-width", 1);
+      .attr("stroke-width", 1)
+      .attr("tabindex", 0);
+
+    points.append("title").text((d) => `${d.label}: ${fmt(d.value)}`);
+
+    
+    const highlightPoint = (circle: SVGCircleElement) => {
+      d3.select(circle).attr("r", 6).attr("stroke-width", 2);
+      polygon.attr("fill", "rgba(31, 119, 180, 0.18)");
+    };
+    const resetPoint = (circle: SVGCircleElement) => {
+      d3.select(circle).attr("r", 3.5).attr("stroke-width", 1);
+      polygon.attr("fill", "rgba(31, 119, 180, 0.12)");
+    };
+
+    // Convert a point's SVG coordinates to container-relative coordinates
+    const toContainerCoords = (cx: number, cy: number) => {
+      const svgEl = svgRef.current!;
+      const containerEl = containerRef.current!;
+      const svgRect = svgEl.getBoundingClientRect();
+      const containerRect = containerEl.getBoundingClientRect();
+      
+      // Calculate the actual SVG dimensions (accounting for viewBox scaling)
+      const svgWidth = svgRect.width;
+      const svgHeight = svgRect.height;
+      const viewBoxWidth = 640;
+      const viewBoxHeight = 500;
+      
+      // Scale factors for viewBox to actual SVG size
+      const scaleX = svgWidth / viewBoxWidth;
+      const scaleY = svgHeight / viewBoxHeight;
+      
+      // Convert from g-space (centered) to viewBox coordinates
+      const viewBoxX = (viewBoxWidth / 2) + cx;
+      const viewBoxY = (viewBoxHeight / 2) + cy;
+      
+      // Scale to actual SVG coordinates
+      const actualX = viewBoxX * scaleX;
+      const actualY = viewBoxY * scaleY;
+      
+      // Convert to container-relative coordinates
+      return {
+        x: actualX + (svgRect.left - containerRect.left),
+        y: actualY + (svgRect.top - containerRect.top)
+      };
+    };
+
+    const showTooltipAtPoint = (label: string, value: number, cx: number, cy: number) => {
+      const { x, y } = toContainerCoords(cx, cy);
+      tooltip
+        .style("opacity", "1")
+        .html(`<strong>${label}</strong><br/>Score: ${fmt(value)}`)
+        .style("left", `${x}px`)
+        .style("top", `${y}px`);
+    };
+
+    const hideTooltip = () => tooltip.style("opacity", "0");
+
+    // interactivity: points (anchor tooltip to the point)
+    points
+      .on("mouseenter", function (_event, d) {
+        const circle = d3.select(this);
+        const cx = +circle.attr("cx");
+        const cy = +circle.attr("cy");
+        highlightPoint(this);
+        showTooltipAtPoint(d.label, d.value, cx, cy);
+      })
+      .on("mouseleave", function () {
+        resetPoint(this);
+        hideTooltip();
+      })
+      .on("focus", function (_event, d) {
+        const circle = d3.select(this);
+        const cx = +circle.attr("cx");
+        const cy = +circle.attr("cy");
+        highlightPoint(this);
+        showTooltipAtPoint(d.label, d.value, cx, cy);
+      })
+      .on("blur", function () {
+        resetPoint(this);
+        hideTooltip();
+      });
 
     // Title
     svg
@@ -180,8 +284,8 @@ export default function RadarChart({ items, title }: Props) {
   }, [items, title]);
 
   return (
-    <Box sx={styles.wrapper}>
-      <Box component="svg" ref={ref} sx={styles.svg} aria-label={title} />
+    <Box ref={containerRef} sx={styles.wrapper}>
+      <Box component="svg" ref={svgRef} sx={styles.svg} aria-label={title} />
     </Box>
   );
 }

--- a/app/components/types.ts
+++ b/app/components/types.ts
@@ -8,3 +8,5 @@ export type AssocRow = {
   score: number;
   datatypeScores: DataTypeScore[];
 };
+
+export type Datum = { label: string; value: number };


### PR DESCRIPTION
## Description
make points and bars interactive
## Changes
- [ ] made points and bars interactive by adding tooltip
- [ ] adjust test to account for the tool tip

## Comments for testing
<img width="1512" height="905" alt="Screenshot 2025-09-05 at 11 41 23" src="https://github.com/user-attachments/assets/b9e64ebd-1371-4974-bd3f-ec0bdfd61306" />
<img width="1512" height="905" alt="Screenshot 2025-09-05 at 11 41 16" src="https://github.com/user-attachments/assets/3d844a1b-ac1b-40f2-a5bf-f90de1aeaaa5" />
